### PR TITLE
Add brand and number fields to maintenance equipment

### DIFF
--- a/maintenance_equipment_brand_number/__init__.py
+++ b/maintenance_equipment_brand_number/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/maintenance_equipment_brand_number/__manifest__.py
+++ b/maintenance_equipment_brand_number/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    "name": "Maintenance Equipment Brand and Number",
+    "version": "16.0.1.0.0",
+    "summary": "Adds brand and unique number to maintenance equipment",
+    "author": "",
+    "license": "LGPL-3",
+    "depends": ["maintenance"],
+    "data": [
+        "views/maintenance_equipment_views.xml",
+    ],
+    "installable": True,
+    "application": False,
+}

--- a/maintenance_equipment_brand_number/models/__init__.py
+++ b/maintenance_equipment_brand_number/models/__init__.py
@@ -1,0 +1,1 @@
+from . import maintenance_equipment

--- a/maintenance_equipment_brand_number/models/maintenance_equipment.py
+++ b/maintenance_equipment_brand_number/models/maintenance_equipment.py
@@ -1,0 +1,12 @@
+from odoo import fields, models
+
+
+class MaintenanceEquipment(models.Model):
+    _inherit = "maintenance.equipment"
+
+    marca = fields.Char(string="Marca")
+    numero = fields.Integer(string="Número", required=True)
+
+    _sql_constraints = [
+        ("numero_unique", "unique(numero)", "El número debe ser único."),
+    ]

--- a/maintenance_equipment_brand_number/views/maintenance_equipment_views.xml
+++ b/maintenance_equipment_brand_number/views/maintenance_equipment_views.xml
@@ -1,0 +1,15 @@
+<odoo>
+    <data>
+        <record id="maintenance_equipment_form_inherit_brand_number" model="ir.ui.view">
+            <field name="name">maintenance.equipment.form.brand.number</field>
+            <field name="model">maintenance.equipment</field>
+            <field name="inherit_id" ref="maintenance.equipment_view_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//sheet/group" position="inside">
+                    <field name="marca"/>
+                    <field name="numero"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
## Summary
- extend maintenance equipment with brand and unique number fields
- show new fields on equipment form view

## Testing
- `python -m py_compile maintenance_equipment_brand_number/__init__.py maintenance_equipment_brand_number/models/__init__.py maintenance_equipment_brand_number/models/maintenance_equipment.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7dd3aa07c8324904b85cf10c12ea6