### PR TITLE
Use sequence to auto-number maintenance equipment

### DIFF
--- a/maintenance_equipment_brand_number/__init__.py
+++ b/maintenance_equipment_brand_number/__init__.py
@@ -1,1 +1,11 @@
 from . import models
+
+from odoo import SUPERUSER_ID, api
+
+
+def post_init_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    seq = env["ir.sequence"]
+    equipments = env["maintenance.equipment"].search([("numero", "=", False)])
+    for equipment in equipments:
+        equipment.numero = seq.next_by_code("maintenance.equipment.numero")

--- a/maintenance_equipment_brand_number/__manifest__.py
+++ b/maintenance_equipment_brand_number/__manifest__.py
@@ -6,8 +6,10 @@
     "license": "LGPL-3",
     "depends": ["maintenance"],
     "data": [
+        "data/ir_sequence.xml",
         "views/maintenance_equipment_views.xml",
     ],
+    "post_init_hook": "post_init_hook",
     "installable": True,
     "application": False,
 }

--- a/maintenance_equipment_brand_number/data/ir_sequence.xml
+++ b/maintenance_equipment_brand_number/data/ir_sequence.xml
@@ -1,0 +1,10 @@
+<odoo>
+    <data noupdate="1">
+        <record id="seq_equipment_numero" model="ir.sequence">
+            <field name="name">Maintenance Equipment Number</field>
+            <field name="code">maintenance.equipment.numero</field>
+            <field name="padding">5</field>
+            <field name="company_id" eval="False"/>
+        </record>
+    </data>
+</odoo>

--- a/maintenance_equipment_brand_number/models/maintenance_equipment.py
+++ b/maintenance_equipment_brand_number/models/maintenance_equipment.py
@@ -5,7 +5,14 @@ class MaintenanceEquipment(models.Model):
     _inherit = "maintenance.equipment"
 
     marca = fields.Char(string="Marca")
-    numero = fields.Integer(string="Número", required=True)
+    numero = fields.Integer(
+        string="Número",
+        required=True,
+        copy=False,
+        default=lambda self: self.env["ir.sequence"].next_by_code(
+            "maintenance.equipment.numero"
+        ),
+    )
 
     _sql_constraints = [
         ("numero_unique", "unique(numero)", "El número debe ser único."),


### PR DESCRIPTION
## Summary
- Generate unique numbers for maintenance equipment using an ir.sequence
- Fill missing equipment numbers on upgrade via post-init hook

## Testing
- `python -m py_compile maintenance_equipment_brand_number/models/maintenance_equipment.py maintenance_equipment_brand_number/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7ef5ae9588324bb4fbe3c745323d5